### PR TITLE
Fixed bug whereby when certain users are added via tokenclaims and a …

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ An example configuration file can be found in `example-config.yaml`. A breakdown
 - `idp_provider_url`: URL of the Identity Provider service.
 - `idp_refresh_directory_interval`: How often the directory information should be refreshed from the Identity Provider.
 - `idp_refresh_directory_timeout`: How long the system should wait for a directory refresh before timing out.
+- `idp_provider_token_claims_user_ttl`: For the `tokenclaims` IdP provider - Determines how long (in seconds) the user will exist in the Veriflow database before being deleted and requiring a re-auth. Default is 604800 (7 days)
 - `signing_key`: RSA private key for signing JWT tokens, encoded in base64.
 - `redirect_base_path`: Base path for redirection URLs. By default `/.veriflow`
 - `jwks_path`: Location of the JSON Web Key Set (JWKS) that can be called to get the public keys of the signing key.

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -29,6 +29,7 @@ idp_provider_user_id_claim: oid
 idp_provider_url: https://login.microsoftonline.com/00000000-1111-2222-3333-444444444444/v2.0
 idp_refresh_directory_interval: 10m
 idp_refresh_directory_timeout: 5m
+idp_provider_token_claims_user_ttl: 604800
 signing_key: "BASE64_ENCODED_RSA_PRIVATE_KEY"
 redirect_base_path: /.veriflow
 jwks_path: /.veriflow/jwks.json

--- a/lib/idp_adapters/tokenclaims.js
+++ b/lib/idp_adapters/tokenclaims.js
@@ -34,6 +34,8 @@ async function addNewUserFromClaims(claims) {
     var currentConfig = getConfig()
     var userId = claims[currentConfig.idp_provider_user_id_claim]
 
+    var expires = currentConfig.idp_provider_token_claims_user_ttl || 604800 // Default user to be removed from Veriflow after 7 days
+
     var userData = {
         vfsid: crypto.randomUUID(),
         id: userId,
@@ -42,7 +44,7 @@ async function addNewUserFromClaims(claims) {
     };
 
     await redisClient.set(`veriflow:users:${userId}`, JSON.stringify(userData))
-    await redisClient.expire(`veriflow:users:${userId}`, 87000); // expire in 24 hours
+    await redisClient.expire(`veriflow:users:${userId}`, expires); // expire in 24 hours
 }
 
 async function getAllUsers() {


### PR DESCRIPTION
…long session is set, the user can get deleted from veriflow before the session is up, resulting in a forbidden screen