### PR TITLE
Added retry flow for failed SSO Callback Verification and Fixed HTTP …

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -62,11 +62,11 @@ app.use(express.urlencoded({ extended: true }))
 
 // Request ID setting middleware
 app.use((req, res, next) => {
-  var requestId = req.get("x-veriflow-request-id")
+  var requestId = req.headers["X-Veriflow-Request-Id"]
   if (!requestId) {
     requestId = randomUUID()
   }
-  req.headers["x-veriflow-request-id"] = requestId
+  req.headers["X-Veriflow-Request-Id"] = requestId
   next()
 })
 

--- a/lib/sso.js
+++ b/lib/sso.js
@@ -331,13 +331,13 @@ async function verifySsoCallback(req, res) {
             var query = req.session.redirect.query
             var baseUrl = new URL(`${protocol}://${host}${path}`)
             var redirectUrl = addParamsToUrl(baseUrl, query)
-            var retries = req.session.retries
-            if (!retries) {
-                req.session.retries = 1
+            var auth_retries = req.session.auth_retries
+            if (!auth_retries) {
+                req.session.auth_retries = 1
             } else {
-                req.session.retries++
+                req.session.auth_retries++
             }
-            log.info({ message: `Retrying auth for user... Retry attempt ${retries}... Redirecting back to original requested URL ${redirectUrl}` })
+            log.info({ message: `Retrying auth for user... Retry attempt ${auth_retries}... Redirecting back to original requested URL ${redirectUrl}` })
             res.redirect(redirectUrl)
             return
         }

--- a/lib/sso.js
+++ b/lib/sso.js
@@ -337,8 +337,8 @@ async function verifySsoCallback(req, res) {
             } else {
                 req.session.auth_retries++
             }
-            log.info({ message: `Retrying auth for user... Retry attempt ${auth_retries}... Redirecting back to original requested URL ${redirectUrl}` })
-            res.redirect(redirectUrl)
+            log.info({ message: `Retrying auth for user... Retry attempt ${auth_retries}... Redirecting back to original requested URL ${redirectUrl.href}` })
+            res.redirect(redirectUrl.href)
             return
         }
         var html = await errorpages.renderErrorPage(500, "ERR_CALLBACK_FAILED", req)

--- a/lib/sso.js
+++ b/lib/sso.js
@@ -324,6 +324,23 @@ async function verifySsoCallback(req, res) {
 
     } catch (error) {
         log.error({ message: "Unknown error occoured in verifySsoCallback", context: { error: error.message, trace: error.stack } })
+        if (req.session.auth_retries <= 3) {
+            var protocol = req.session.redirect.protocol
+            var host = req.session.redirect.host
+            var path = req.session.redirect.path
+            var query = req.session.redirect.query
+            var baseUrl = new URL(`${protocol}://${host}${path}`)
+            var redirectUrl = addParamsToUrl(baseUrl, query)
+            var retries = req.session.retries
+            if (!retries) {
+                req.session.retries = 1
+            } else {
+                req.session.retries++
+            }
+            log.info({ message: `Retrying auth for user... Retry attempt ${retries}... Redirecting back to original requested URL ${redirectUrl}` })
+            res.redirect(redirectUrl)
+            return
+        }
         var html = await errorpages.renderErrorPage(500, "ERR_CALLBACK_FAILED", req)
         res.status(500).send(html)
     }

--- a/test/e2e/tests/basic_test.js
+++ b/test/e2e/tests/basic_test.js
@@ -54,6 +54,9 @@ Scenario('Testing Unauthorized Flow', async ({ I }) => {
     I.amOnPage('http://test-unauthorized-login.localtest.me/');
     I.login()
     I.see("Forbidden")
+    I.click(".hamburger-menu")
+    I.see("Request ID")
+    I.dontSee("fallback")
 });
 
 Scenario('Advanced matchers test', async ({ I }) => {

--- a/util/errorpage.js
+++ b/util/errorpage.js
@@ -1,7 +1,7 @@
 import ejs from 'ejs';
 import path from 'path';
 import { getConfig, getRedirectBasepath } from '../util/config.js';
-
+import { randomUUID } from 'node:crypto'
 
 async function renderErrorPage(status_code, error_code_override, req) {
     var config = getConfig();
@@ -67,7 +67,7 @@ async function renderErrorPage(status_code, error_code_override, req) {
         additional_css: additional_css,
         show_error_code: show_error_code,
         logo_image_src: logo_image_src,
-        request_id: req?.headers["X-Veriflow-Request-Id"] || "{http.request.uuid}",
+        request_id: req?.headers["X-Veriflow-Request-Id"] || `fallback-${randomUUID()}`,
         request_host: request_host
     });
     return html

--- a/util/logging.js
+++ b/util/logging.js
@@ -5,7 +5,7 @@ const log = pino();
 log.level = 30
 
 log.access = (action, route, user, req) => {
-    let reqId = req.headers["x-veriflow-request-id"]
+    let reqId = req.headers["X-Veriflow-Request-Id"]
     let method = req.get("X-Forwarded-Method")
     let path = req.get("X-Forwarded-Path")
     let query = req.get("X-Forwarded-Query")


### PR DESCRIPTION
…Reqest Header

Previous to this comment we had a problem with ssoVerifyCallback, that in many cases the state would be out of sync. I added a simple retry mechanism toretry the request again if it fails.

I also fixed an issue with the display of the veriflow-request-id.