### PR TITLE
Making error pages better and fixing redirect

### DIFF
--- a/lib/sso.js
+++ b/lib/sso.js
@@ -324,14 +324,14 @@ async function verifySsoCallback(req, res) {
 
     } catch (error) {
         log.error({ message: "Unknown error occoured in verifySsoCallback", context: { error: error.message, trace: error.stack } })
-        if (req.session.auth_retries <= 3) {
+        var auth_retries = req.session.auth_retries
+        if (!auth_retries || auth_retries <= 3) {
             var protocol = req.session.redirect.protocol
             var host = req.session.redirect.host
             var path = req.session.redirect.path
             var query = req.session.redirect.query
             var baseUrl = new URL(`${protocol}://${host}${path}`)
             var redirectUrl = addParamsToUrl(baseUrl, query)
-            var auth_retries = req.session.auth_retries
             if (!auth_retries) {
                 req.session.auth_retries = 1
             } else {
@@ -341,7 +341,7 @@ async function verifySsoCallback(req, res) {
             res.redirect(redirectUrl.href)
             return
         }
-        var html = await errorpages.renderErrorPage(500, "ERR_CALLBACK_FAILED", req)
+        var html = await errorpages.renderErrorPage(500, "ERR_CALLBACK_FAILED", req, req.session.redirect.host)
         res.status(500).send(html)
     }
 }

--- a/util/errorpage.js
+++ b/util/errorpage.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { getConfig, getRedirectBasepath } from '../util/config.js';
 import { randomUUID } from 'node:crypto'
 
-async function renderErrorPage(status_code, error_code_override, req) {
+async function renderErrorPage(status_code, error_code_override, req, host_override) {
     var config = getConfig();
     var redirectBasePath = getRedirectBasepath()
     var logoutUrlObj = new URL(`${config.service_url}${redirectBasePath}/logout`)
@@ -15,7 +15,7 @@ async function renderErrorPage(status_code, error_code_override, req) {
     var footer_text = config?.ui?.error_page_footer_text || "Veriflow Access Proxy"
     var background_image_url = config?.ui?.error_page_background || false
     var additional_css = config?.ui?.error_page_additional_css || false
-    var request_host = req?.get("X-Forwarded-Host") || "{http.request.host}"
+    var request_host = host_override || req?.get("X-Forwarded-Host") || logoutUrlObj.host
     if (config?.ui?.error_page_show_host === false) {
         request_host = null
     }


### PR DESCRIPTION
Now the error page on verifySsoRedirect will show the URL of the originally requested site, not the Veriflow URL.
With safe fallbacks